### PR TITLE
docs: fix incorrect example of list_entry_groups

### DIFF
--- a/google/cloud/datacatalog_v1/gapic/data_catalog_client.py
+++ b/google/cloud/datacatalog_v1/gapic/data_catalog_client.py
@@ -753,7 +753,7 @@ class DataCatalogClient(object):
             >>>
             >>> client = datacatalog_v1.DataCatalogClient()
             >>>
-            >>> parent = client.entry_group_path('[PROJECT]', '[LOCATION]', '[ENTRY_GROUP]')
+            >>> parent = client.location_path('[PROJECT]', '[LOCATION]')
             >>>
             >>> # Iterate over all results
             >>> for element in client.list_entry_groups(parent):


### PR DESCRIPTION
It is not possible to list entry groups in entry group, location_path should be used in example instead.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-datacatalog/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
