### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ include: Entries (Data Catalog representation of a cloud resource).
 - `Product Documentation`_
 
 .. |ga| image:: https://img.shields.io/badge/support-GA-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-datacatalog.svg
    :target: https://pypi.org/project/google-cloud-datacatalog/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog.svg
@@ -92,4 +92,4 @@ Next Steps
    APIs that we cover.
 
 .. _Google Cloud Data Catalog API Product documentation:  https://cloud.google.com/data-catalog
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.