### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datacatalog ",
     "name_pretty": "Google Cloud Data Catalog",
     "product_documentation": "https://cloud.google.com/data-catalog",
-    "client_documentation": "https://googleapis.dev/python/datacatalog/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datacatalog/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ include: Entries (Data Catalog representation of a cloud resource).
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datacatalog.svg
    :target: https://pypi.org/project/google-cloud-datacatalog/
 .. _Google Cloud Data Catalog API: https://cloud.google.com/data-catalog
-.. _Client Library Documentation: https://googleapis.dev/python/datacatalog/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datacatalog/latest
 .. _Product Documentation:  https://cloud.google.com/data-catalog
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.