### PR TITLE
fix(deps): move libcst to extras

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,7 +22,7 @@ If you experience issues or have questions, please file an [issue](https://githu
 * Install the library
 
 ```py
-python3 -m pip install google-cloud-datacatalog
+python3 -m pip install google-cloud-datacatalog[libcst]
 ```
 
 * The script `fixup_datacatalog_v1_keywords.py` is shipped with the library. It expects

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,10 @@ dependencies = [
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
-    "libcst >= 0.2.5",
     "proto-plus >= 1.4.0",
 ]
+
+extras = {"libcst >= 0.2.5"}
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
@@ -84,6 +85,7 @@ setuptools.setup(
     ],
     namespace_packages=namespaces,
     install_requires=dependencies,
+    extras_require=extras,
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     "proto-plus >= 1.4.0",
 ]
 
-extras = {"libcst >= 0.2.5"}
+extras = {"libcst": "libcst >= 0.2.5"}
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
`libcst` is only used by the fixup script.