### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v1 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,9 +65,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-datacatalog"
-copyright = u"2019, Google"
-author = u"Google APIs"
+project = "google-cloud-datacatalog"
+copyright = "2019, Google"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -261,7 +261,7 @@ latex_documents = [
     (
         master_doc,
         "google-cloud-datacatalog.tex",
-        u"google-cloud-datacatalog Documentation",
+        "google-cloud-datacatalog Documentation",
         author,
         "manual",
     )
@@ -296,7 +296,7 @@ man_pages = [
     (
         master_doc,
         "google-cloud-datacatalog",
-        u"google-cloud-datacatalog Documentation",
+        "google-cloud-datacatalog Documentation",
         [author],
         1,
     )
@@ -315,7 +315,7 @@ texinfo_documents = [
     (
         master_doc,
         "google-cloud-datacatalog",
-        u"google-cloud-datacatalog Documentation",
+        "google-cloud-datacatalog Documentation",
         author,
         "google-cloud-datacatalog",
         "google-cloud-datacatalog Library",

--- a/google/cloud/datacatalog_v1/proto/datacatalog_pb2_grpc.py
+++ b/google/cloud/datacatalog_v1/proto/datacatalog_pb2_grpc.py
@@ -14,15 +14,15 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 class DataCatalogStub(object):
     """Data Catalog API service allows clients to discover, understand, and manage
-  their data.
-  """
+    their data.
+    """
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.SearchCatalog = channel.unary_unary(
             "/google.cloud.datacatalog.v1.DataCatalog/SearchCatalog",
             request_serializer=google_dot_cloud_dot_datacatalog__v1_dot_proto_dot_datacatalog__pb2.SearchCatalogRequest.SerializeToString,
@@ -162,27 +162,27 @@ class DataCatalogStub(object):
 
 class DataCatalogServicer(object):
     """Data Catalog API service allows clients to discover, understand, and manage
-  their data.
-  """
+    their data.
+    """
 
     def SearchCatalog(self, request, context):
         """Searches Data Catalog for multiple resources like entries, tags that
-    match a query.
+        match a query.
 
-    This is a custom method
-    (https://cloud.google.com/apis/design/custom_methods) and does not return
-    the complete resource, only the resource identifier and high level
-    fields. Clients can subsequentally call `Get` methods.
+        This is a custom method
+        (https://cloud.google.com/apis/design/custom_methods) and does not return
+        the complete resource, only the resource identifier and high level
+        fields. Clients can subsequentally call `Get` methods.
 
-    Note that Data Catalog search queries do not guarantee full recall. Query
-    results that match your query may not be returned, even in subsequent
-    result pages. Also note that results returned (and not returned) can vary
-    across repeated search queries.
+        Note that Data Catalog search queries do not guarantee full recall. Query
+        results that match your query may not be returned, even in subsequent
+        result pages. Also note that results returned (and not returned) can vary
+        across repeated search queries.
 
-    See [Data Catalog Search
-    Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
-    for more information.
-    """
+        See [Data Catalog Search
+        Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+        for more information.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -190,303 +190,295 @@ class DataCatalogServicer(object):
     def CreateEntryGroup(self, request, context):
         """Creates an EntryGroup.
 
-    An entry group contains logically related entries together with Cloud
-    Identity and Access Management policies that specify the users who can
-    create, edit, and view entries within the entry group.
+        An entry group contains logically related entries together with Cloud
+        Identity and Access Management policies that specify the users who can
+        create, edit, and view entries within the entry group.
 
-    Data Catalog automatically creates an entry group for BigQuery entries
-    ("@bigquery") and Pub/Sub topics ("@pubsub"). Users create their own entry
-    group to contain Cloud Storage fileset entries or custom type entries,
-    and the IAM policies associated with those entries. Entry groups, like
-    entries, can be searched.
+        Data Catalog automatically creates an entry group for BigQuery entries
+        ("@bigquery") and Pub/Sub topics ("@pubsub"). Users create their own entry
+        group to contain Cloud Storage fileset entries or custom type entries,
+        and the IAM policies associated with those entries. Entry groups, like
+        entries, can be searched.
 
-    A maximum of 10,000 entry groups may be created per organization across all
-    locations.
+        A maximum of 10,000 entry groups may be created per organization across all
+        locations.
 
-    Users should enable the Data Catalog API in the project identified by
-    the `parent` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `parent` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetEntryGroup(self, request, context):
-        """Gets an EntryGroup.
-    """
+        """Gets an EntryGroup."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateEntryGroup(self, request, context):
         """Updates an EntryGroup. The user should enable the Data Catalog API in the
-    project identified by the `entry_group.name` parameter (see [Data Catalog
-    Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        project identified by the `entry_group.name` parameter (see [Data Catalog
+        Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteEntryGroup(self, request, context):
         """Deletes an EntryGroup. Only entry groups that do not contain entries can be
-    deleted. Users should enable the Data Catalog API in the project
-    identified by the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        deleted. Users should enable the Data Catalog API in the project
+        identified by the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListEntryGroups(self, request, context):
-        """Lists entry groups.
-    """
+        """Lists entry groups."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateEntry(self, request, context):
         """Creates an entry. Only entries of 'FILESET' type or user-specified type can
-    be created.
+        be created.
 
-    Users should enable the Data Catalog API in the project identified by
-    the `parent` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
+        Users should enable the Data Catalog API in the project identified by
+        the `parent` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
 
-    A maximum of 100,000 entries may be created per entry group.
-    """
+        A maximum of 100,000 entries may be created per entry group.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateEntry(self, request, context):
         """Updates an existing entry.
-    Users should enable the Data Catalog API in the project identified by
-    the `entry.name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `entry.name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteEntry(self, request, context):
         """Deletes an existing entry. Only entries created through
-    [CreateEntry][google.cloud.datacatalog.v1.DataCatalog.CreateEntry]
-    method can be deleted.
-    Users should enable the Data Catalog API in the project identified by
-    the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        [CreateEntry][google.cloud.datacatalog.v1.DataCatalog.CreateEntry]
+        method can be deleted.
+        Users should enable the Data Catalog API in the project identified by
+        the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetEntry(self, request, context):
-        """Gets an entry.
-    """
+        """Gets an entry."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def LookupEntry(self, request, context):
         """Get an entry by target resource name. This method allows clients to use
-    the resource name from the source Google Cloud Platform service to get the
-    Data Catalog Entry.
-    """
+        the resource name from the source Google Cloud Platform service to get the
+        Data Catalog Entry.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListEntries(self, request, context):
-        """Lists entries.
-    """
+        """Lists entries."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateTagTemplate(self, request, context):
         """Creates a tag template. The user should enable the Data Catalog API in
-    the project identified by the `parent` parameter (see [Data Catalog
-    Resource
-    Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
-    for more information).
-    """
+        the project identified by the `parent` parameter (see [Data Catalog
+        Resource
+        Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+        for more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetTagTemplate(self, request, context):
-        """Gets a tag template.
-    """
+        """Gets a tag template."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateTagTemplate(self, request, context):
         """Updates a tag template. This method cannot be used to update the fields of
-    a template. The tag template fields are represented as separate resources
-    and should be updated using their own create/update/delete methods.
-    Users should enable the Data Catalog API in the project identified by
-    the `tag_template.name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        a template. The tag template fields are represented as separate resources
+        and should be updated using their own create/update/delete methods.
+        Users should enable the Data Catalog API in the project identified by
+        the `tag_template.name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteTagTemplate(self, request, context):
         """Deletes a tag template and all tags using the template.
-    Users should enable the Data Catalog API in the project identified by
-    the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateTagTemplateField(self, request, context):
         """Creates a field in a tag template. The user should enable the Data Catalog
-    API in the project identified by the `parent` parameter (see
-    [Data Catalog Resource
-    Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
-    for more information).
-    """
+        API in the project identified by the `parent` parameter (see
+        [Data Catalog Resource
+        Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+        for more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateTagTemplateField(self, request, context):
         """Updates a field in a tag template. This method cannot be used to update the
-    field type. Users should enable the Data Catalog API in the project
-    identified by the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        field type. Users should enable the Data Catalog API in the project
+        identified by the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def RenameTagTemplateField(self, request, context):
         """Renames a field in a tag template. The user should enable the Data Catalog
-    API in the project identified by the `name` parameter (see [Data Catalog
-    Resource
-    Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
-    for more information).
-    """
+        API in the project identified by the `name` parameter (see [Data Catalog
+        Resource
+        Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+        for more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteTagTemplateField(self, request, context):
         """Deletes a field in a tag template and all uses of that field.
-    Users should enable the Data Catalog API in the project identified by
-    the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateTag(self, request, context):
         """Creates a tag on an [Entry][google.cloud.datacatalog.v1.Entry].
-    Note: The project identified by the `parent` parameter for the
-    [tag](https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.entryGroups.entries.tags/create#path-parameters)
-    and the
-    [tag
-    template](https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.tagTemplates/create#path-parameters)
-    used to create the tag must be from the same organization.
-    """
+        Note: The project identified by the `parent` parameter for the
+        [tag](https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.entryGroups.entries.tags/create#path-parameters)
+        and the
+        [tag
+        template](https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.tagTemplates/create#path-parameters)
+        used to create the tag must be from the same organization.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateTag(self, request, context):
-        """Updates an existing tag.
-    """
+        """Updates an existing tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteTag(self, request, context):
-        """Deletes a tag.
-    """
+        """Deletes a tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListTags(self, request, context):
-        """Lists the tags on an [Entry][google.cloud.datacatalog.v1.Entry].
-    """
+        """Lists the tags on an [Entry][google.cloud.datacatalog.v1.Entry]."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def SetIamPolicy(self, request, context):
         """Sets the access control policy for a resource. Replaces any existing
-    policy.
-    Supported resources are:
-    - Tag templates.
-    - Entries.
-    - Entry groups.
-    Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
-    and any external Google Cloud Platform resources synced to Data Catalog.
+        policy.
+        Supported resources are:
+        - Tag templates.
+        - Entries.
+        - Entry groups.
+        Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+        and any external Google Cloud Platform resources synced to Data Catalog.
 
-    Callers must have following Google IAM permission
-    - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
-    templates.
-    - `datacatalog.entries.setIamPolicy` to set policies on entries.
-    - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
-    """
+        Callers must have following Google IAM permission
+        - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
+        templates.
+        - `datacatalog.entries.setIamPolicy` to set policies on entries.
+        - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetIamPolicy(self, request, context):
         """Gets the access control policy for a resource. A `NOT_FOUND` error
-    is returned if the resource does not exist. An empty policy is returned
-    if the resource exists but does not have a policy set on it.
+        is returned if the resource does not exist. An empty policy is returned
+        if the resource exists but does not have a policy set on it.
 
-    Supported resources are:
-    - Tag templates.
-    - Entries.
-    - Entry groups.
-    Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
-    and any external Google Cloud Platform resources synced to Data Catalog.
+        Supported resources are:
+        - Tag templates.
+        - Entries.
+        - Entry groups.
+        Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+        and any external Google Cloud Platform resources synced to Data Catalog.
 
-    Callers must have following Google IAM permission
-    - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
-    templates.
-    - `datacatalog.entries.getIamPolicy` to get policies on entries.
-    - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
-    """
+        Callers must have following Google IAM permission
+        - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
+        templates.
+        - `datacatalog.entries.getIamPolicy` to get policies on entries.
+        - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def TestIamPermissions(self, request, context):
         """Returns the caller's permissions on a resource.
-    If the resource does not exist, an empty set of permissions is returned
-    (We don't return a `NOT_FOUND` error).
+        If the resource does not exist, an empty set of permissions is returned
+        (We don't return a `NOT_FOUND` error).
 
-    Supported resources are:
-    - Tag templates.
-    - Entries.
-    - Entry groups.
-    Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
-    and any external Google Cloud Platform resources synced to Data Catalog.
+        Supported resources are:
+        - Tag templates.
+        - Entries.
+        - Entry groups.
+        Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+        and any external Google Cloud Platform resources synced to Data Catalog.
 
-    A caller is not required to have Google IAM permission to make this
-    request.
-    """
+        A caller is not required to have Google IAM permission to make this
+        request.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/google/cloud/datacatalog_v1beta1/gapic/policy_tag_manager_client.py
+++ b/google/cloud/datacatalog_v1beta1/gapic/policy_tag_manager_client.py
@@ -202,8 +202,10 @@ class PolicyTagManagerClient(object):
                     )
                 self.transport = transport
         else:
-            self.transport = policy_tag_manager_grpc_transport.PolicyTagManagerGrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials
+            self.transport = (
+                policy_tag_manager_grpc_transport.PolicyTagManagerGrpcTransport(
+                    address=api_endpoint, channel=channel, credentials=credentials
+                )
             )
 
         if client_info is None:

--- a/google/cloud/datacatalog_v1beta1/proto/datacatalog_pb2_grpc.py
+++ b/google/cloud/datacatalog_v1beta1/proto/datacatalog_pb2_grpc.py
@@ -14,15 +14,15 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 class DataCatalogStub(object):
     """Data Catalog API service allows clients to discover, understand, and manage
-  their data.
-  """
+    their data.
+    """
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.SearchCatalog = channel.unary_unary(
             "/google.cloud.datacatalog.v1beta1.DataCatalog/SearchCatalog",
             request_serializer=google_dot_cloud_dot_datacatalog__v1beta1_dot_proto_dot_datacatalog__pb2.SearchCatalogRequest.SerializeToString,
@@ -162,319 +162,311 @@ class DataCatalogStub(object):
 
 class DataCatalogServicer(object):
     """Data Catalog API service allows clients to discover, understand, and manage
-  their data.
-  """
+    their data.
+    """
 
     def SearchCatalog(self, request, context):
         """Searches Data Catalog for multiple resources like entries, tags that
-    match a query.
+        match a query.
 
-    This is a custom method
-    (https://cloud.google.com/apis/design/custom_methods) and does not return
-    the complete resource, only the resource identifier and high level
-    fields. Clients can subsequentally call `Get` methods.
+        This is a custom method
+        (https://cloud.google.com/apis/design/custom_methods) and does not return
+        the complete resource, only the resource identifier and high level
+        fields. Clients can subsequentally call `Get` methods.
 
-    Note that Data Catalog search queries do not guarantee full recall. Query
-    results that match your query may not be returned, even in subsequent
-    result pages. Also note that results returned (and not returned) can vary
-    across repeated search queries.
+        Note that Data Catalog search queries do not guarantee full recall. Query
+        results that match your query may not be returned, even in subsequent
+        result pages. Also note that results returned (and not returned) can vary
+        across repeated search queries.
 
-    See [Data Catalog Search
-    Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
-    for more information.
-    """
+        See [Data Catalog Search
+        Syntax](https://cloud.google.com/data-catalog/docs/how-to/search-reference)
+        for more information.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateEntryGroup(self, request, context):
         """A maximum of 10,000 entry groups may be created per organization across all
-    locations.
+        locations.
 
-    Users should enable the Data Catalog API in the project identified by
-    the `parent` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `parent` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateEntryGroup(self, request, context):
         """Updates an EntryGroup. The user should enable the Data Catalog API in the
-    project identified by the `entry_group.name` parameter (see [Data Catalog
-    Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        project identified by the `entry_group.name` parameter (see [Data Catalog
+        Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetEntryGroup(self, request, context):
-        """Gets an EntryGroup.
-    """
+        """Gets an EntryGroup."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteEntryGroup(self, request, context):
         """Deletes an EntryGroup. Only entry groups that do not contain entries can be
-    deleted. Users should enable the Data Catalog API in the project
-    identified by the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        deleted. Users should enable the Data Catalog API in the project
+        identified by the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListEntryGroups(self, request, context):
-        """Lists entry groups.
-    """
+        """Lists entry groups."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateEntry(self, request, context):
         """Creates an entry. Only entries of 'FILESET' type or user-specified type can
-    be created.
+        be created.
 
-    Users should enable the Data Catalog API in the project identified by
-    the `parent` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
+        Users should enable the Data Catalog API in the project identified by
+        the `parent` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
 
-    A maximum of 100,000 entries may be created per entry group.
-    """
+        A maximum of 100,000 entries may be created per entry group.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateEntry(self, request, context):
         """Updates an existing entry.
-    Users should enable the Data Catalog API in the project identified by
-    the `entry.name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `entry.name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteEntry(self, request, context):
         """Deletes an existing entry. Only entries created through
-    [CreateEntry][google.cloud.datacatalog.v1beta1.DataCatalog.CreateEntry]
-    method can be deleted.
-    Users should enable the Data Catalog API in the project identified by
-    the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        [CreateEntry][google.cloud.datacatalog.v1beta1.DataCatalog.CreateEntry]
+        method can be deleted.
+        Users should enable the Data Catalog API in the project identified by
+        the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetEntry(self, request, context):
-        """Gets an entry.
-    """
+        """Gets an entry."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def LookupEntry(self, request, context):
         """Get an entry by target resource name. This method allows clients to use
-    the resource name from the source Google Cloud Platform service to get the
-    Data Catalog Entry.
-    """
+        the resource name from the source Google Cloud Platform service to get the
+        Data Catalog Entry.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListEntries(self, request, context):
-        """Lists entries.
-    """
+        """Lists entries."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateTagTemplate(self, request, context):
         """Creates a tag template. The user should enable the Data Catalog API in
-    the project identified by the `parent` parameter (see [Data Catalog
-    Resource
-    Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
-    for more information).
-    """
+        the project identified by the `parent` parameter (see [Data Catalog
+        Resource
+        Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+        for more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetTagTemplate(self, request, context):
-        """Gets a tag template.
-    """
+        """Gets a tag template."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateTagTemplate(self, request, context):
         """Updates a tag template. This method cannot be used to update the fields of
-    a template. The tag template fields are represented as separate resources
-    and should be updated using their own create/update/delete methods.
-    Users should enable the Data Catalog API in the project identified by
-    the `tag_template.name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        a template. The tag template fields are represented as separate resources
+        and should be updated using their own create/update/delete methods.
+        Users should enable the Data Catalog API in the project identified by
+        the `tag_template.name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteTagTemplate(self, request, context):
         """Deletes a tag template and all tags using the template.
-    Users should enable the Data Catalog API in the project identified by
-    the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateTagTemplateField(self, request, context):
         """Creates a field in a tag template. The user should enable the Data Catalog
-    API in the project identified by the `parent` parameter (see
-    [Data Catalog Resource
-    Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
-    for more information).
-    """
+        API in the project identified by the `parent` parameter (see
+        [Data Catalog Resource
+        Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+        for more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateTagTemplateField(self, request, context):
         """Updates a field in a tag template. This method cannot be used to update the
-    field type. Users should enable the Data Catalog API in the project
-    identified by the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        field type. Users should enable the Data Catalog API in the project
+        identified by the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def RenameTagTemplateField(self, request, context):
         """Renames a field in a tag template. The user should enable the Data Catalog
-    API in the project identified by the `name` parameter (see [Data Catalog
-    Resource
-    Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
-    for more information).
-    """
+        API in the project identified by the `name` parameter (see [Data Catalog
+        Resource
+        Project](https://cloud.google.com/data-catalog/docs/concepts/resource-project)
+        for more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteTagTemplateField(self, request, context):
         """Deletes a field in a tag template and all uses of that field.
-    Users should enable the Data Catalog API in the project identified by
-    the `name` parameter (see [Data Catalog Resource Project]
-    (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
-    more information).
-    """
+        Users should enable the Data Catalog API in the project identified by
+        the `name` parameter (see [Data Catalog Resource Project]
+        (https://cloud.google.com/data-catalog/docs/concepts/resource-project) for
+        more information).
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateTag(self, request, context):
         """Creates a tag on an [Entry][google.cloud.datacatalog.v1beta1.Entry].
-    Note: The project identified by the `parent` parameter for the
-    [tag](https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.entryGroups.entries.tags/create#path-parameters)
-    and the
-    [tag
-    template](https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.tagTemplates/create#path-parameters)
-    used to create the tag must be from the same organization.
-    """
+        Note: The project identified by the `parent` parameter for the
+        [tag](https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.entryGroups.entries.tags/create#path-parameters)
+        and the
+        [tag
+        template](https://cloud.google.com/data-catalog/docs/reference/rest/v1beta1/projects.locations.tagTemplates/create#path-parameters)
+        used to create the tag must be from the same organization.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateTag(self, request, context):
-        """Updates an existing tag.
-    """
+        """Updates an existing tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteTag(self, request, context):
-        """Deletes a tag.
-    """
+        """Deletes a tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListTags(self, request, context):
-        """Lists the tags on an [Entry][google.cloud.datacatalog.v1beta1.Entry].
-    """
+        """Lists the tags on an [Entry][google.cloud.datacatalog.v1beta1.Entry]."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def SetIamPolicy(self, request, context):
         """Sets the access control policy for a resource. Replaces any existing
-    policy.
-    Supported resources are:
-    - Tag templates.
-    - Entries.
-    - Entry groups.
-    Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
-    and any external Google Cloud Platform resources synced to Data Catalog.
+        policy.
+        Supported resources are:
+        - Tag templates.
+        - Entries.
+        - Entry groups.
+        Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+        and any external Google Cloud Platform resources synced to Data Catalog.
 
-    Callers must have following Google IAM permission
-    - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
-    templates.
-    - `datacatalog.entries.setIamPolicy` to set policies on entries.
-    - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
-    """
+        Callers must have following Google IAM permission
+        - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
+        templates.
+        - `datacatalog.entries.setIamPolicy` to set policies on entries.
+        - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetIamPolicy(self, request, context):
         """Gets the access control policy for a resource. A `NOT_FOUND` error
-    is returned if the resource does not exist. An empty policy is returned
-    if the resource exists but does not have a policy set on it.
+        is returned if the resource does not exist. An empty policy is returned
+        if the resource exists but does not have a policy set on it.
 
-    Supported resources are:
-    - Tag templates.
-    - Entries.
-    - Entry groups.
-    Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
-    and any external Google Cloud Platform resources synced to Data Catalog.
+        Supported resources are:
+        - Tag templates.
+        - Entries.
+        - Entry groups.
+        Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+        and any external Google Cloud Platform resources synced to Data Catalog.
 
-    Callers must have following Google IAM permission
-    - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
-    templates.
-    - `datacatalog.entries.getIamPolicy` to get policies on entries.
-    - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
-    """
+        Callers must have following Google IAM permission
+        - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
+        templates.
+        - `datacatalog.entries.getIamPolicy` to get policies on entries.
+        - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def TestIamPermissions(self, request, context):
         """Returns the caller's permissions on a resource.
-    If the resource does not exist, an empty set of permissions is returned
-    (We don't return a `NOT_FOUND` error).
+        If the resource does not exist, an empty set of permissions is returned
+        (We don't return a `NOT_FOUND` error).
 
-    Supported resources are:
-    - Tag templates.
-    - Entries.
-    - Entry groups.
-    Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
-    and any external Google Cloud Platform resources synced to Data Catalog.
+        Supported resources are:
+        - Tag templates.
+        - Entries.
+        - Entry groups.
+        Note, this method cannot be used to manage policies for BigQuery, Pub/Sub
+        and any external Google Cloud Platform resources synced to Data Catalog.
 
-    A caller is not required to have Google IAM permission to make this
-    request.
-    """
+        A caller is not required to have Google IAM permission to make this
+        request.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/google/cloud/datacatalog_v1beta1/proto/policytagmanager_pb2_grpc.py
+++ b/google/cloud/datacatalog_v1beta1/proto/policytagmanager_pb2_grpc.py
@@ -11,15 +11,15 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 class PolicyTagManagerStub(object):
     """The policy tag manager API service allows clients to manage their taxonomies
-  and policy tags.
-  """
+    and policy tags.
+    """
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.CreateTaxonomy = channel.unary_unary(
             "/google.cloud.datacatalog.v1beta1.PolicyTagManager/CreateTaxonomy",
             request_serializer=google_dot_cloud_dot_datacatalog__v1beta1_dot_proto_dot_policytagmanager__pb2.CreateTaxonomyRequest.SerializeToString,
@@ -89,99 +89,89 @@ class PolicyTagManagerStub(object):
 
 class PolicyTagManagerServicer(object):
     """The policy tag manager API service allows clients to manage their taxonomies
-  and policy tags.
-  """
+    and policy tags.
+    """
 
     def CreateTaxonomy(self, request, context):
-        """Creates a taxonomy in the specified project.
-    """
+        """Creates a taxonomy in the specified project."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteTaxonomy(self, request, context):
         """Deletes a taxonomy. This operation will also delete all
-    policy tags in this taxonomy along with their associated policies.
-    """
+        policy tags in this taxonomy along with their associated policies.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateTaxonomy(self, request, context):
-        """Updates a taxonomy.
-    """
+        """Updates a taxonomy."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListTaxonomies(self, request, context):
         """Lists all taxonomies in a project in a particular location that the caller
-    has permission to view.
-    """
+        has permission to view.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetTaxonomy(self, request, context):
-        """Gets a taxonomy.
-    """
+        """Gets a taxonomy."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreatePolicyTag(self, request, context):
-        """Creates a policy tag in the specified taxonomy.
-    """
+        """Creates a policy tag in the specified taxonomy."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeletePolicyTag(self, request, context):
-        """Deletes a policy tag. Also deletes all of its descendant policy tags.
-    """
+        """Deletes a policy tag. Also deletes all of its descendant policy tags."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdatePolicyTag(self, request, context):
-        """Updates a policy tag.
-    """
+        """Updates a policy tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def ListPolicyTags(self, request, context):
-        """Lists all policy tags in a taxonomy.
-    """
+        """Lists all policy tags in a taxonomy."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetPolicyTag(self, request, context):
-        """Gets a policy tag.
-    """
+        """Gets a policy tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetIamPolicy(self, request, context):
-        """Gets the IAM policy for a taxonomy or a policy tag.
-    """
+        """Gets the IAM policy for a taxonomy or a policy tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def SetIamPolicy(self, request, context):
-        """Sets the IAM policy for a taxonomy or a policy tag.
-    """
+        """Sets the IAM policy for a taxonomy or a policy tag."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def TestIamPermissions(self, request, context):
         """Returns the permissions that a caller has on the specified taxonomy or
-    policy tag.
-    """
+        policy tag.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/google/cloud/datacatalog_v1beta1/proto/policytagmanagerserialization_pb2_grpc.py
+++ b/google/cloud/datacatalog_v1beta1/proto/policytagmanagerserialization_pb2_grpc.py
@@ -8,15 +8,15 @@ from google.cloud.datacatalog_v1beta1.proto import (
 
 class PolicyTagManagerSerializationStub(object):
     """Policy tag manager serialization API service allows clients to manipulate
-  their taxonomies and policy tags data with serialized format.
-  """
+    their taxonomies and policy tags data with serialized format.
+    """
 
     def __init__(self, channel):
         """Constructor.
 
-    Args:
-      channel: A grpc.Channel.
-    """
+        Args:
+          channel: A grpc.Channel.
+        """
         self.ImportTaxonomies = channel.unary_unary(
             "/google.cloud.datacatalog.v1beta1.PolicyTagManagerSerialization/ImportTaxonomies",
             request_serializer=google_dot_cloud_dot_datacatalog__v1beta1_dot_proto_dot_policytagmanagerserialization__pb2.ImportTaxonomiesRequest.SerializeToString,
@@ -31,16 +31,16 @@ class PolicyTagManagerSerializationStub(object):
 
 class PolicyTagManagerSerializationServicer(object):
     """Policy tag manager serialization API service allows clients to manipulate
-  their taxonomies and policy tags data with serialized format.
-  """
+    their taxonomies and policy tags data with serialized format.
+    """
 
     def ImportTaxonomies(self, request, context):
         """Imports all taxonomies and their policy tags to a project as new
-    taxonomies.
+        taxonomies.
 
-    This method provides a bulk taxonomy / policy tag creation using nested
-    proto structure.
-    """
+        This method provides a bulk taxonomy / policy tag creation using nested
+        proto structure.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -48,9 +48,9 @@ class PolicyTagManagerSerializationServicer(object):
     def ExportTaxonomies(self, request, context):
         """Exports all taxonomies and their policy tags in a project.
 
-    This method generates SerializedTaxonomy protos with nested policy tags
-    that can be used as an input for future ImportTaxonomies calls.
-    """
+        This method generates SerializedTaxonomy protos with nested policy tags
+        that can be used as an input for future ImportTaxonomies calls.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,14 +23,19 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==19.3b0"
+BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 if os.path.exists("samples"):
     BLACK_PATHS.append("samples")
 
+DEFAULT_PYTHON_VERSION = "3.8"
 
-@nox.session(python="3.7")
+# Error if a python version is missing
+nox.options.error_on_missing_interpreters = True
+
+
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint(session):
     """Run linters.
 
@@ -42,7 +47,7 @@ def lint(session):
     session.run("flake8", "google", "tests")
 
 
-@nox.session(python="3.6")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):
     """Run black.
 
@@ -56,7 +61,7 @@ def blacken(session):
     session.run("black", *BLACK_PATHS)
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
     session.install("docutils", "pygments")
@@ -90,7 +95,7 @@ def unit(session):
     default(session)
 
 
-@nox.session(python=["2.7", "3.7"])
+@nox.session(python=["2.7", "3.8"])
 def system(session):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
@@ -120,7 +125,7 @@ def system(session):
         session.run("py.test", "--quiet", system_test_folder_path, *session.posargs)
 
 
-@nox.session(python=["2.7", "3.7"])
+@nox.session(python=["2.7", "3.8"])
 def samples(session):
     requirements_path = os.path.join("samples", "requirements.txt")
     requirements_exists = os.path.exists(requirements_path)
@@ -137,7 +142,7 @@ def samples(session):
     session.run("py.test", "--quiet", "samples", *session.posargs)
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def cover(session):
     """Run the final coverage report.
 
@@ -150,12 +155,12 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx<3.0.0", "alabaster", "recommonmark")
+    session.install("sphinx<3.0.0", "alabaster", "recommonmark", "Jinja2<3.1")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/samples/v1beta1/datacatalog_get_entry.py
+++ b/samples/v1beta1/datacatalog_get_entry.py
@@ -50,9 +50,9 @@ def sample_get_entry(project_id, location_id, entry_group_id, entry_id):
 
     response = client.get_entry(name)
     entry = response
-    print(u"Entry name: {}".format(entry.name))
-    print(u"Entry type: {}".format(enums.EntryType(entry.type).name))
-    print(u"Linked resource: {}".format(entry.linked_resource))
+    print("Entry name: {}".format(entry.name))
+    print("Entry type: {}".format(enums.EntryType(entry.type).name))
+    print("Linked resource: {}".format(entry.linked_resource))
 
 
 # [END datacatalog_get_entry]

--- a/samples/v1beta1/datacatalog_lookup_entry.py
+++ b/samples/v1beta1/datacatalog_lookup_entry.py
@@ -47,9 +47,9 @@ def sample_lookup_entry(resource_name):
     # resource_name = '[Full Resource Name]'
     response = client.lookup_entry(linked_resource=resource_name)
     entry = response
-    print(u"Entry name: {}".format(entry.name))
-    print(u"Entry type: {}".format(enums.EntryType(entry.type).name))
-    print(u"Linked resource: {}".format(entry.linked_resource))
+    print("Entry name: {}".format(entry.name))
+    print("Entry type: {}".format(enums.EntryType(entry.type).name))
+    print("Linked resource: {}".format(entry.linked_resource))
 
 
 # [END datacatalog_lookup_entry]

--- a/samples/v1beta1/datacatalog_lookup_entry_sql_resource.py
+++ b/samples/v1beta1/datacatalog_lookup_entry_sql_resource.py
@@ -46,9 +46,9 @@ def sample_lookup_entry(sql_name):
     # sql_name = '[SQL Resource Name]'
     response = client.lookup_entry(sql_resource=sql_name)
     entry = response
-    print(u"Entry name: {}".format(entry.name))
-    print(u"Entry type: {}".format(enums.EntryType(entry.type).name))
-    print(u"Linked resource: {}".format(entry.linked_resource))
+    print("Entry name: {}".format(entry.name))
+    print("Entry type: {}".format(enums.EntryType(entry.type).name))
+    print("Linked resource: {}".format(entry.linked_resource))
 
 
 # [END datacatalog_lookup_entry_sql_resource]

--- a/samples/v1beta1/datacatalog_search.py
+++ b/samples/v1beta1/datacatalog_search.py
@@ -56,15 +56,13 @@ def sample_search_catalog(include_project_id, include_gcp_public_datasets, query
     # Iterate over all results
     for response_item in client.search_catalog(scope, query):
         print(
-            u"Result type: {}".format(
+            "Result type: {}".format(
                 enums.SearchResultType(response_item.search_result_type).name
             )
         )
-        print(u"Result subtype: {}".format(response_item.search_result_subtype))
-        print(
-            u"Relative resource name: {}".format(response_item.relative_resource_name)
-        )
-        print(u"Linked resource: {}\n".format(response_item.linked_resource))
+        print("Result subtype: {}".format(response_item.search_result_subtype))
+        print("Relative resource name: {}".format(response_item.relative_resource_name))
+        print("Linked resource: {}\n".format(response_item.linked_resource))
 
 
 # [END datacatalog_search]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "1.0.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v1**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566